### PR TITLE
feat: Add support for configurable OpenAI-like LLM providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,9 @@
 OPENAI_API_KEY=
+
+# LLM Configuration
+# LLM_PROVIDER: Specify the LLM provider (e.g., "openai", "custom"). Default is "openai".
+LLM_PROVIDER=openai
+# LLM_API_BASE_URL: Optional. The base URL for the LLM API. Use for custom OpenAI-like endpoints.
+# LLM_API_BASE_URL=
+# LLM_MODEL_NAME: The model name to be used (e.g., "gpt-4o-mini", "custom-model"). Default is "gpt-4o-mini".
+LLM_MODEL_NAME=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -145,7 +145,32 @@ cp .env.example .env
 ```plaintext
 # OpenAI Configuration
 OPENAI_API_KEY=your-api-key-here
+
+# LLM Configuration (Optional - Defaults are suitable for standard OpenAI usage)
+# LLM_PROVIDER: Specify the LLM provider. Default is "openai".
+# Use "openai" for standard OpenAI services.
+# For custom OpenAI-compatible APIs (e.g., local LLMs, other cloud providers),
+# you can set this to a custom identifier or keep it as "openai" if the API behaves like OpenAI's.
+LLM_PROVIDER=openai
+
+# LLM_API_BASE_URL: Optional. Use this to specify the base URL for custom OpenAI-like API endpoints.
+# This is necessary if you are not using the default OpenAI API endpoint.
+# Example: LLM_API_BASE_URL=http://localhost:8080/v1
+# LLM_API_BASE_URL=
+
+# LLM_MODEL_NAME: Specify the model name to be used for generating responses.
+# Default is "gpt-4o-mini". Change this if you want to use a different model
+# available through your configured provider and API base.
+LLM_MODEL_NAME=gpt-4o-mini
 ```
+
+   **Details on LLM Environment Variables:**
+    - `OPENAI_API_KEY`: Your API key for OpenAI services. This is required if `LLM_PROVIDER` is "openai" or if your custom LLM provider (specified via `LLM_API_BASE_URL`) uses an OpenAI-compatible API key.
+    - `LLM_PROVIDER`: Defines the LLM provider.
+        - Defaults to `"openai"`.
+        - If you're using a custom OpenAI-compatible service (like a local LLM that mimics the OpenAI API), you might set this to your provider's name or keep it as `"openai"`, depending on how you want to manage configurations. The primary driver for custom endpoints is `LLM_API_BASE_URL`.
+    - `LLM_API_BASE_URL`: (Optional) Use this to set a custom API endpoint for OpenAI-like services. This is crucial if you are using a local LLM (e.g., via LM Studio, Ollama with an OpenAI-compatible interface) or another cloud provider that offers an OpenAI-compatible API. If this is set, the `openai` library will direct requests to this URL.
+    - `LLM_MODEL_NAME`: Specifies the model to be used for generating responses (e.g., "gpt-4o-mini", "gpt-4", or a custom model name if using a local LLM). Defaults to `"gpt-4o-mini"`. Ensure the model selected is available at the configured API endpoint.
 
 ### 5. Verify Installation
 ```bash

--- a/src/GPTResponder.py
+++ b/src/GPTResponder.py
@@ -17,19 +17,52 @@ class GPTResponder:
         self._last_processed_id = None
         # 初始化OpenAI配置
         if not self._initialize_openai():
-            raise ValueError("Failed to initialize OpenAI configuration. Please check your API key.")
+            raise ValueError("Failed to initialize OpenAI configuration. Please check your API key and LLM settings.")
 
     def _initialize_openai(self) -> bool:
         """
-        初始化OpenAI配置
+        初始化OpenAI或兼容的LLM配置
         
         Returns:
             bool: 初始化成功返回True，否则返回False
         """
-        if not EnvConfig.ensure_api_key():
-            return False
-            
-        openai.api_key = EnvConfig.get_openai_key()
+        llm_provider = EnvConfig.get_llm_provider()
+        api_base_url = EnvConfig.get_llm_api_base_url()
+
+        if api_base_url:
+            openai.api_base = api_base_url
+            print(f"Using custom API base URL: {api_base_url}")
+
+        # Proceed with API key setup if it's OpenAI or an OpenAI-compatible API (indicated by api_base_url)
+        if llm_provider == "openai" or api_base_url:
+            if not EnvConfig.ensure_api_key(): # This check is now conditional in EnvConfig
+                print("API key check failed for OpenAI or custom OpenAI-compatible provider.")
+                return False
+            openai.api_key = EnvConfig.get_openai_key()
+            print(f"Using OpenAI API key for provider: {llm_provider}")
+        elif llm_provider != "openai":
+            # Handle other providers if necessary in the future.
+            # For now, if it's not 'openai' and no api_base is set,
+            # we assume it might be a configuration for a different, non-OpenAI SDK integration.
+            # The current structure will likely fail if it's not OpenAI compatible.
+            print(f"LLM Provider is '{llm_provider}'. No API key or base URL configured for direct OpenAI SDK usage.")
+            # Depending on future providers, we might return True or handle differently.
+            # For now, if it's not openai and no base_url, it implies we can't use openai SDK directly.
+            # However, ensure_api_key in EnvConfig is already provider-aware.
+            # Let's rely on ensure_api_key's logic for now.
+            if not EnvConfig.ensure_api_key():
+                 print(f"API key check failed for provider: {llm_provider}")
+                 return False
+            # If a non-OpenAI provider still uses an API key set via OPENAI_API_KEY, it would be loaded here.
+            # This part might need refinement when other providers are actively supported.
+            loaded_key = EnvConfig.get_openai_key()
+            if loaded_key and loaded_key != 'your_api_key_here':
+                openai.api_key = loaded_key # This might be okay if the other provider uses a similar key mechanism
+                print(f"Loaded API key for provider: {llm_provider}. Behavior depends on provider's SDK/API.")
+            else:
+                print(f"No specific API key found or configured for non-OpenAI provider '{llm_provider}' via OPENAI_API_KEY.")
+
+
         return True
 
     def _generate_response_from_transcript(self, lastContent, latest_response_text="", latest_response_q_text="", current_response_id=None):
@@ -67,9 +100,13 @@ class GPTResponder:
             content = create_prompt(recent_speakers, lastContent, latest_response_text)
             #print(f"Created prompt: {content}")
 
+            # Get model name from config
+            model_name = EnvConfig.get_llm_model_name()
+            print(f"Using LLM model: {model_name}")
+
             # 使用流式API
             stream = openai.chat.completions.create(
-                model="gpt-4o-mini",
+                model=model_name,
                 messages=[
                     {"role": "system", "content": SystemConfig.get_system_role()},
                     {"role": "user", "content": content},

--- a/src/config.py
+++ b/src/config.py
@@ -53,6 +53,9 @@ class EnvConfig:
     
     _instance = None
     _initialized = False
+    _llm_provider = "openai"  # Default LLM provider
+    _llm_api_base_url = None  # Default API base URL (optional)
+    _llm_model_name = "gpt-4o-mini"  # Default model name
     
     def __new__(cls):
         if cls._instance is None:
@@ -77,9 +80,14 @@ class EnvConfig:
         # 加载.env文件
         load_dotenv(env_path)
         
+        # Load LLM configuration from environment variables
+        cls._llm_provider = os.getenv('LLM_PROVIDER', cls._llm_provider)
+        cls._llm_api_base_url = os.getenv('LLM_API_BASE_URL', cls._llm_api_base_url)
+        cls._llm_model_name = os.getenv('LLM_MODEL_NAME', cls._llm_model_name)
+
         # 验证API密钥
-        if not os.getenv('OPENAI_API_KEY'):
-            print(f"OPENAI_API_KEY not found in {env_path}")
+        if cls._llm_provider == "openai" and not os.getenv('OPENAI_API_KEY'):
+            print(f"OPENAI_API_KEY not found in {env_path} (required for OpenAI provider)")
             print("Please add your OpenAI API key to the .env file")
             return
         
@@ -91,6 +99,14 @@ class EnvConfig:
         template = (
             "# OpenAI API Configuration\n"
             "OPENAI_API_KEY=your_api_key_here\n"
+            "\n"
+            "# LLM Configuration (Optional)\n"
+            "# LLM_PROVIDER: The LLM provider to use (e.g., 'openai', 'custom'). Default: 'openai'\n"
+            "LLM_PROVIDER=openai\n"
+            "# LLM_API_BASE_URL: Custom API base URL for the LLM provider (e.g., for local LLMs). Optional.\n"
+            "# LLM_API_BASE_URL=\n"
+            "# LLM_MODEL_NAME: The specific model name to use. Default: 'gpt-4o-mini'\n"
+            "LLM_MODEL_NAME=gpt-4o-mini\n"
             "\n"
             "# Add other configuration variables below\n"
         )
@@ -106,11 +122,33 @@ class EnvConfig:
         if not cls._initialized:
             cls.initialize()
         return os.getenv('OPENAI_API_KEY')
+
+    @classmethod
+    def get_llm_provider(cls) -> str:
+        if not cls._initialized:
+            cls.initialize()
+        return cls._llm_provider
+
+    @classmethod
+    def get_llm_api_base_url(cls) -> Optional[str]:
+        if not cls._initialized:
+            cls.initialize()
+        return cls._llm_api_base_url
+
+    @classmethod
+    def get_llm_model_name(cls) -> str:
+        if not cls._initialized:
+            cls.initialize()
+        return cls._llm_model_name
     
     @classmethod
     def ensure_api_key(cls) -> bool:
-        api_key = cls.get_openai_key()
-        return bool(api_key and api_key != 'your_api_key_here')
+        # This check is now more nuanced; depends on the provider
+        if cls.get_llm_provider() == "openai":
+            api_key = cls.get_openai_key()
+            return bool(api_key and api_key != 'your_api_key_here')
+        # For other providers, API key might not be 'OPENAI_API_KEY' or might not be required
+        return True
 
 class SystemConfig:
     _instance = None


### PR DESCRIPTION
This change introduces the ability to configure the application to use different OpenAI-like LLM providers by setting new environment variables.

The following environment variables have been added:
- LLM_PROVIDER: Specifies the LLM provider (e.g., "openai", "custom"). Defaults to "openai".
- LLM_API_BASE_URL: Optional. The base URL for the LLM API, allowing connection to custom OpenAI-compatible endpoints (e.g., local LLMs).
- LLM_MODEL_NAME: Specifies the model name to be used for generating responses (e.g., "gpt-4o-mini", "llama3-8b-instruct"). Defaults to "gpt-4o-mini".

The `GPTResponder` has been updated to use these configurations, allowing it to connect to different API endpoints and use different models. The `.env.example` file and `README.md` have been updated to reflect these new configuration options and guide you on how to use them.